### PR TITLE
Bugfixes

### DIFF
--- a/ipq/utils.py
+++ b/ipq/utils.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import functools
 import re
 import shutil
+import sys
 import typing as t
 
 from ipq import errors
@@ -76,3 +77,10 @@ class Colors:
     BLUE = "\033[1;34m"
     PURPLE = "\033[1;35m"
     CYAN = "\033[1;36m"
+
+
+if not sys.stdout.isatty():
+    for attr in dir(Colors):
+        if not attr.startswith("_"):
+            # Disable color if not in a TTY
+            setattr(Colors, attr, "")


### PR DESCRIPTION
Closes #3 
Closes #4 

Removed threads as any error messages were thrown as tracebacks inside the thread, they never hit our exception handler in the main process.

Use `typing.List` instead of `list` for type hints.